### PR TITLE
Fix install nugetpackage

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -1,7 +1,6 @@
 NUGET
-  remote: https://nuget.org/api/v2
-  specs:
+  remote: https://www.nuget.org/api/v2
     NuGet.CommandLine (2.8.6)
     Pester (4.0.8)
-    Unic.Bob.Wendy (3.0.0)
-    Unic.Bob.Keith (2.0.0)
+    Unic.Bob.Keith (2.0.2)
+    Unic.Bob.Wendy (3.0)


### PR DESCRIPTION
I replaced the usage of Nuget.Core in Install-NugetPackage with nuget CLI
This brakes the current Function signature as IPackage is not supported anymore
Is it enough to just tag it as a major version and then update the dependency in Dizzy? (which I also updated)