### PR TITLE
Removing Nuget.CommandLine version < 3 restriction

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,6 +1,6 @@
 source https://nuget.org/api/v2
 
 nuget Pester
-nuget NuGet.CommandLine < 3
+nuget NuGet.CommandLine
 nuget Unic.Bob.Keith
 nuget Unic.Bob.Wendy

--- a/paket.lock
+++ b/paket.lock
@@ -1,6 +1,6 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-    NuGet.CommandLine (2.8.6)
-    Pester (4.0.8)
+    NuGet.CommandLine (5.3.1)
+    Pester (4.9)
     Unic.Bob.Keith (2.0.2)
-    Unic.Bob.Wendy (3.0)
+    Unic.Bob.Wendy (3.1)

--- a/src/Skip/Install-NugetPackage.ps1
+++ b/src/Skip/Install-NugetPackage.ps1
@@ -49,7 +49,7 @@ function Install-NugetPackage
         if($Source) {
             $args = $args + @("-Source", $Source)
         }
-        & $nuget $args
+        & $nuget $args | Out-Null
 
         $InstallPath = Join-Path $OutputLocation $PackageId
 


### PR DESCRIPTION
Is there any reason we are using the Nuget.CommandLine < 3?
When I was setting up a project recently this was a reason why I was not able to authenticate to TC. Switching to newer version of the command line tool resolved my problems.