### PR TITLE
Speed up build time with ensure "WinVerifyTrust" isn't triggered for each project and file while building projects

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -3,4 +3,4 @@ NUGET
     NuGet.CommandLine (5.3.1)
     Pester (4.9)
     Unic.Bob.Keith (2.0.2)
-    Unic.Bob.Wendy (3.1)
+    Unic.Bob.Wendy (3.2)

--- a/src/Skip/Skip.psm1
+++ b/src/Skip/Skip.psm1
@@ -2,7 +2,7 @@ $PSScriptRoot = Split-Path  $script:MyInvocation.MyCommand.Path
 
 $ErrorActionPreference = "Stop"
 
-Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.tests.ps1 | Foreach-Object{ . $_.FullName }
+Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.tests.ps1 | Foreach-Object{ . ([scriptblock]::Create([io.file]::ReadAllText($_.FullName))) }
 Export-ModuleMember -Function * -Alias *
 
 function ResolvePath() {


### PR DESCRIPTION
Since few weeks we faced the issue that projects are built much slower then usually. This is a fix for that.